### PR TITLE
fix(installer): backup restore-miss, pre-upgrade version, resolution menu + qt UI font

### DIFF
--- a/config/qt5ct/qt5ct.conf
+++ b/config/qt5ct/qt5ct.conf
@@ -7,7 +7,7 @@ style=kvantum
 
 [Fonts]
 fixed="Fira Code Medium,12,-1,5,57,0,0,0,0,0,Regular"
-general="Fira Code Medium,14,-1,5,57,0,0,0,0,0,Regular"
+general="Noto Sans,14,-1,5,50,0,0,0,0,0,Regular"
 
 [Interface]
 activate_item_on_single_click=1

--- a/config/qt6ct/qt6ct.conf
+++ b/config/qt6ct/qt6ct.conf
@@ -7,7 +7,7 @@ style=kvantum
 
 [Fonts]
 fixed="Fira Code Medium,12,-1,5,500,0,0,0,0,0,0,0,0,0,0,1,Regular"
-general="Fira Code Medium,14,-1,5,500,0,0,0,0,0,0,0,0,0,0,1,Regular"
+general="Noto Sans,14,-1,5,400,0,0,0,0,0,0,0,0,0,0,1,Regular"
 
 [Interface]
 activate_item_on_single_click=1

--- a/copy.sh
+++ b/copy.sh
@@ -182,6 +182,12 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 INSTALLED_VERSION=$(get_installed_dotfiles_version)
+
+# Fix the backup-directory suffix once for the whole run (parent shell) so every
+# backup and its matching restore reference the same path even if the wall-clock
+# minute changes between them. get_backup_dirname() honors this exported value.
+export KOOL_RUN_BACKUP_SUFFIX="back-up_$(date +"%m%d_%H%M")"
+
 EXPRESS_SUPPORTED=0
 if express_supported; then
   EXPRESS_SUPPORTED=1
@@ -437,10 +443,10 @@ fi
 
 printf "\\n%.0s" {1..1}
 
-# Capture installed dotfiles version at the start of the workflow so we
-# can apply cleanup rules based on the pre-upgrade state, even if a newer
-# version marker is copied in later.
-INSTALLED_VERSION_AT_START="$(get_installed_dotfiles_version || true)"
+# Reuse the version captured before copy_phase2 overwrote the hypr tree, so
+# restore/cleanup rules see the pre-upgrade state. Re-reading the marker here
+# would pick up the freshly copied (new) version and defeat the version gate.
+INSTALLED_VERSION_AT_START="$INSTALLED_VERSION"
 
 # quickshell (ags alternative)
 # Check if quickshell is installed

--- a/scripts/lib_backup.sh
+++ b/scripts/lib_backup.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 # Backup helper utilities shared by copy.sh (and future scripts).
 
-# Create a unique backup directory name with month, day, hours, and minutes.
+# Backup-directory suffix shared across a single installer run.
+#
+# Every backup created during a run and every later restore must agree on this
+# name. Callers use command substitution -- $(get_backup_dirname) -- so a
+# function-local cache would not survive the subshell; instead copy.sh exports
+# KOOL_RUN_BACKUP_SUFFIX once in the parent shell and we honor it here. Without
+# it (standalone callers) we fall back to a fresh timestamp.
 get_backup_dirname() {
-  echo "back-up_$(date +"%m%d_%H%M")"
+  if [ -n "${KOOL_RUN_BACKUP_SUFFIX:-}" ]; then
+    printf '%s\n' "$KOOL_RUN_BACKUP_SUFFIX"
+  else
+    printf '%s\n' "back-up_$(date +"%m%d_%H%M")"
+  fi
 }
 
 # Move a directory to a timestamped backup alongside the original.

--- a/scripts/lib_prompts.sh
+++ b/scripts/lib_prompts.sh
@@ -144,19 +144,22 @@ prompt_resolution_choice() {
 
   local choice
   while true; do
-    echo "${INFO:-[INFO]} Select monitor resolution for scaling:"
-    echo "  1) < 1440p   (lower DPI; smaller displays)"
-    echo "  2) ≥ 1440p   (default; 1440p/2k/4k)"
+    # The caller captures this function via command substitution, so only the
+    # resolved value ("< 1440p"/"≥ 1440p") may go to stdout. All user-facing UI
+    # must go to stderr or it gets swallowed and the menu never displays.
+    echo "${INFO:-[INFO]} Select monitor resolution for scaling:" >&2
+    echo "  1) < 1440p   (lower DPI; smaller displays)" >&2
+    echo "  2) ≥ 1440p   (default; 1440p/2k/4k)" >&2
 
     if ! read -r -p "${CAT} Enter the number of your choice (1 or 2): " choice </dev/tty; then
-      echo "${ERROR} Unable to read input (tty unavailable)."
+      echo "${ERROR} Unable to read input (tty unavailable)." >&2
       continue
     fi
-    echo "${INFO:-[INFO]} You entered: '$choice'"
+    echo "${INFO:-[INFO]} You entered: '$choice'" >&2
     case "$choice" in
       1) echo "< 1440p"; return ;;
       2) echo "≥ 1440p"; return ;;
-      *) echo "${ERROR} Invalid choice. Please enter 1 for < 1440p or 2 for ≥ 1440p." ;;
+      *) echo "${ERROR} Invalid choice. Please enter 1 for < 1440p or 2 for ≥ 1440p." >&2 ;;
     esac
   done
 }


### PR DESCRIPTION
Found while running the v2.3.20 → v2.3.22 upgrade on a multi-monitor host. An audit of the upgrade path surfaced two real correctness bugs and one UX bug; a fourth fix clears the post-upgrade audit warning.

## 1. Restore-miss on minute rollover (`copy.sh`, `scripts/lib_backup.sh`)
`get_backup_dirname()` stamps the backup suffix with `date +%m%d_%H%M` and was called independently when each backup is created (`copy_phase2`, ags, quickshell, …) and again by every restore step (`restore_hypr_assets`/`restore_user_configs`/`restore_user_scripts`/`restore_hypr_files`). If the wall-clock minute ticked over between creating a backup and restoring from it, the recomputed suffix no longer matched and the restore was **silently skipped** — leaving fresh v2.3.x defaults for `monitors.conf`, `workspaces.conf`, `UserConfigs`, `UserScripts` and `hyprlock.conf` (data survived in the backup dir, just not auto-restored).

Callers use command substitution, so a function-local cache can't survive the subshell. `copy.sh` now exports `KOOL_RUN_BACKUP_SUFFIX` once in the parent shell and `get_backup_dirname()` honors it (fresh-stamp fallback for standalone callers). Result: one suffix per run, so every backup and its later restore always agree.

## 2. Pre-upgrade version read too late (`copy.sh`)
`INSTALLED_VERSION_AT_START` was computed *after* `copy_phase2` had already overwritten the hypr tree, so it read the **new** version marker and defeated the version-gated restore path (legacy `<2.3.19` handling). It now reuses `INSTALLED_VERSION`, captured before any copy. (Verified live: the run correctly logged "detected version v2.3.20" for cleanup.)

## 3. Resolution menu never displayed (`scripts/lib_prompts.sh`)
`prompt_resolution_choice()` is captured via `resolution="$(prompt_resolution_choice)"`, so its stdout is swallowed. The "Select monitor resolution" header and the `1) < 1440p / 2) ≥ 1440p` legend were plain `echo`s to stdout and never reached the terminal — only the `read -p` prompt showed (read writes to stderr), leaving the user at a bare "Enter the number of your choice (1 or 2):" with no menu. UI now goes to stderr; only the resolved value stays on stdout.

## 4. qt5ct/qt6ct general UI font (`config/qt5ct`, `config/qt6ct`)
`general` was `Fira Code Medium` (monospace), so every Qt app rendered its whole UI in monospace — flagged by `lib_audit.sh`. Set `general` to **Noto Sans** to match the GTK UI font (`org.gnome.desktop.interface font-name`); `fixed` stays Fira Code for terminals/code views.

## Testing
- `bash -n` on all changed scripts.
- Confirmed the per-run suffix is identical across command-substitution subshells and immune to a simulated minute boundary, with the standalone fallback intact.
- Confirmed the resolution menu renders (stderr) while only the value is captured (stdout).
- Ran the real `--upgrade` end-to-end: UserConfigs / monitors / workspaces / F-key scheme all preserved, version cleanup saw the pre-upgrade v2.3.20, no `hyprctl configerrors`, audit font warning cleared.