### PR TITLE
fix: preserve theme payloads across upgrades, route logout via Logout.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ## Fixed
 
+- `copy.sh`: upgrades wiped externally-installed theme payloads. `copy_phase2`
+  replaces `qt5ct`/`qt6ct`/`Kvantum` wholesale, and the theme-state snapshot
+  only preserved the top-level configs — so after an upgrade, `qt6ct.conf` and
+  `kvantum.kvconfig` pointed at `Hackerer-Dark` color-scheme/theme files that
+  no longer existed, silently reverting Qt apps to a default palette. The
+  snapshot now also captures `qt5ct/colors`, `qt6ct/colors`, and `Kvantum/`
+  and restores any files the new release doesn't ship (fill-in only, so
+  repo-shipped scheme updates still land).
+- Logout now goes through `Logout.sh` (the wlogout "logout" button and the
+  `CTRL ALT Delete` keybind in `Keybinds.conf` previously ran
+  `hyprctl dispatch exit 0` directly; the lua keybind already used it).
+  Killing the compositor out from under its Wayland clients made the
+  xdg-desktop-portal implementations, swaync, nm-applet, etc. die on a broken
+  pipe as failed systemd user units, which fumon then reported as portal
+  errors at the next login. `Logout.sh` shuts the session down via
+  hyprshutdown/loginctl/uwsm so units are stopped cleanly first.
 - `copy.sh`: every express upgrade (and any interactive run declining the
   Hackerer theme) silently aborted at the theme prompt — the function's
   "declined/skipped" return code tripped `set -e`, skipping the exec-bit

--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -78,7 +78,7 @@ bindd = $mainMod CTRL, F11, move workspace to up monitor, movecurrentworkspaceto
 bindd = $mainMod CTRL, F12, move workspace to down monitor, movecurrentworkspacetomonitor, d
 
 #### SYSTEM ####
-bindd = CTRL ALT, Delete, exit Hyprland, exec, hyprctl dispatch exit 0
+bindd = CTRL ALT, Delete, exit Hyprland, exec, $scriptsDir/Logout.sh
 bindd = $mainMod, Q, close active window, killactive,
 bindd = $mainMod SHIFT, Q, Terminate active process, exec, $scriptsDir/KillActiveProcess.sh
 bindd = CTRL ALT, L, lock screen, exec, $scriptsDir/LockScreen.sh

--- a/config/wlogout/layout
+++ b/config/wlogout/layout
@@ -18,7 +18,7 @@
 }
 {
     "label" : "logout",
-    "action" : "hyprctl dispatch exit 0",
+    "action" : "$HOME/.config/hypr/scripts/Logout.sh",
     "text" : "LOGOUT",
     "keybind" : "e"
 }

--- a/scripts/lib_copy.sh
+++ b/scripts/lib_copy.sh
@@ -9,7 +9,8 @@
 
 snapshot_theme_state() {
   local state_dir="$1"
-  mkdir -p "$state_dir"
+  rm -rf "$state_dir"
+  mkdir -p "$state_dir/conf" "$state_dir/extra"
 
   local theme_files=(
     "$HOME/.config/qt5ct/qt5ct.conf"
@@ -25,8 +26,25 @@ snapshot_theme_state() {
   for src in "${theme_files[@]}"; do
     [ -f "$src" ] || continue
     local rel="${src#$HOME/.config/}"
-    mkdir -p "$state_dir/$(dirname "$rel")"
-    cp -p "$src" "$state_dir/$rel"
+    mkdir -p "$state_dir/conf/$(dirname "$rel")"
+    cp -p "$src" "$state_dir/conf/$rel"
+  done
+
+  # Theme payloads installed by external theme packs (e.g. Hackerer) live
+  # inside directories copy_phase2 replaces wholesale. Snapshot them so
+  # schemes the shipped configs don't include survive the upgrade —
+  # otherwise the restored confs above point at files that no longer exist.
+  local payload_dirs=(
+    "$HOME/.config/qt5ct/colors"
+    "$HOME/.config/qt6ct/colors"
+    "$HOME/.config/Kvantum"
+  )
+
+  for src in "${payload_dirs[@]}"; do
+    [ -d "$src" ] || continue
+    local rel="${src#$HOME/.config/}"
+    mkdir -p "$state_dir/extra/$(dirname "$rel")"
+    cp -rp "$src" "$state_dir/extra/$rel"
   done
 }
 
@@ -114,13 +132,25 @@ restore_theme_state() {
   local restored=0
   [ -d "$state_dir" ] || return 0
 
+  # Exact restore: these files decide which theme is active.
   while IFS= read -r -d '' saved; do
-    local rel="${saved#$state_dir/}"
+    local rel="${saved#$state_dir/conf/}"
     local dst="$HOME/.config/$rel"
     mkdir -p "$(dirname "$dst")"
     cp -p "$saved" "$dst" 2>&1 | tee -a "$log"
     restored=1
-  done < <(find "$state_dir" -type f -print0)
+  done < <(find "$state_dir/conf" -type f -print0 2>/dev/null)
+
+  # Fill-in restore: put back theme payloads (color schemes, Kvantum theme
+  # dirs) the new release doesn't ship, without overwriting files it does.
+  while IFS= read -r -d '' saved; do
+    local rel="${saved#$state_dir/extra/}"
+    local dst="$HOME/.config/$rel"
+    [ -e "$dst" ] && continue
+    mkdir -p "$(dirname "$dst")"
+    cp -p "$saved" "$dst" 2>&1 | tee -a "$log"
+    restored=1
+  done < <(find "$state_dir/extra" -type f -print0 2>/dev/null)
 
   if [ "$restored" -eq 1 ]; then
     echo "${INFO:-[INFO]} Restored local visual theme state from pre-upgrade snapshot." 2>&1 | tee -a "$log"


### PR DESCRIPTION
## Summary

Fixes two regressions that surfaced after the last express upgrade.

### Upgrades wiped externally-installed theme payloads

`copy_phase2` replaces `qt5ct`/`qt6ct`/`Kvantum` wholesale, and the theme-state snapshot only preserved the top-level configs. After an upgrade, `qt6ct.conf` and `kvantum.kvconfig` still pointed at `Hackerer-Dark` color-scheme/theme files that no longer existed, silently reverting Qt apps to a default palette (in express mode nothing reinstalls the theme, so the breakage persisted).

`snapshot_theme_state` now also captures `qt5ct/colors`, `qt6ct/colors`, and `Kvantum/`; `restore_theme_state` puts back any files the new release doesn't ship. The payload restore is fill-in only, so scheme files the repo does ship still get their updates.

### Logout killed the compositor out from under its Wayland clients

The wlogout "logout" button and the `CTRL ALT Delete` binding in `Keybinds.conf` ran `hyprctl dispatch exit 0` directly. The compositor exited first, so the xdg-desktop-portal backends, swaync, nm-applet, etc. died on a broken pipe as failed systemd user units, which fumon reported as portal errors at the next login (xdph 1.3.12 additionally segfaults in teardown). Both paths now go through `Logout.sh` (hyprshutdown → loginctl → uwsm stop) like the lua keybind already did, so units stop cleanly before the compositor exits.

Companion image-side fix: syndr/phalanx#41 (merged) and syndr/phalanx#42 gate portal-backend D-Bus activation on `graphical-session.target`.

## Testing

- `bash -n scripts/lib_copy.sh`
- Simulated a full wipe-and-upgrade cycle against the new snapshot/restore in a throwaway `$HOME`: Hackerer payload and confs restored, repo-shipped Catppuccin update not clobbered (5/5 checks)
- Theme reinstalled and logout routing verified live on a 4-output workstation