### PR TITLE
fix(dropterminal): never adopt an unrelated window at spawn

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -40,7 +40,10 @@ bindd = $mainMod SHIFT, F, fullscreen, fullscreen
 bindd = $mainMod CTRL, F, maximize window, fullscreen, 1
 bindd = $mainMod, SPACE, Float current window, togglefloating,
 bindd = $mainMod ALT, SPACE, Float all windows, exec, hyprctl dispatch workspaceopt allfloat
-bindd = $mainMod SHIFT, Return, DropDown terminal, exec, $scriptsDir/Dropterminal.sh $term
+# Dropdown must match the Startup_Apps.conf preload terminal. Not $term:
+# wezterm is single-process, so the scratchpad exec rules can't attach to
+# its windows and the dropdown machinery breaks.
+bindd = $mainMod SHIFT, Return, DropDown terminal, exec, $scriptsDir/Dropterminal.sh kitty
 
 # Desktop zooming or magnifier
 bindd = $mainMod ALT, mouse_down, zoom in, exec, hyprctl keyword cursor:zoom_factor "$(hyprctl getoption cursor:zoom_factor | awk 'NR==1 {factor = $2; if (factor < 1) {factor = 1}; print factor * 2.0}')"

--- a/config/hypr/configs/Startup_Apps.conf
+++ b/config/hypr/configs/Startup_Apps.conf
@@ -22,8 +22,10 @@ exec-once = $scriptsDir/KeybindsLayoutInit.sh
 # Xwayland-Video-Bridge-Hide window rule, which can lose the login race.
 exec-once = $scriptsDir/HideXwaylandBridge.sh
 
-# Initialize Drop Down terminal - See Bug#810 https://github.com/JaKooLit/Hyprland-Dots/issues/810#issuecomment-3351947644
-exec-once = $HOME/.config/hypr/scripts/Dropterminal.sh kitty &
+# Preload the Drop Down terminal hidden in the scratchpad (--preload never
+# reveals or focuses at login). The terminal must match the DropDown keybind
+# in Keybinds.conf. See Bug#810 https://github.com/JaKooLit/Hyprland-Dots/issues/810#issuecomment-3351947644
+exec-once = $HOME/.config/hypr/scripts/Dropterminal.sh --preload kitty &
 exec-once = $scriptsDir/Polkit.sh
 exec-once = nm-applet --indicator
 exec-once = nm-tray   # For ubuntu

--- a/config/hypr/scripts/Dropterminal.sh
+++ b/config/hypr/scripts/Dropterminal.sh
@@ -4,13 +4,16 @@
 # Made and brought to by Kiran George
 # /* -- ✨ https://github.com/SherLock707 ✨ -- */  ##
 # Dropdown Terminal
-# Usage: ./Dropdown.sh [-d] <terminal_command>
+# Usage: ./Dropdown.sh [-d] [-p|--preload] <terminal_command>
 # Example: ./Dropdown.sh foot
 #          ./Dropdown.sh -d foot (with debug output)
+#          ./Dropdown.sh -p foot (ensure it exists hidden in the scratchpad
+#                                 without revealing it — for exec-once at login)
 #          ./Dropdown.sh "kitty -e zsh"
 #          ./Dropdown.sh "alacritty --working-directory /home/user"
 
 DEBUG=false
+PRELOAD=false
 SPECIAL_WS="special:scratchpad"
 ADDR_FILE="/tmp/dropdown_terminal_addr"
 
@@ -25,14 +28,17 @@ SLIDE_STEPS=5
 SLIDE_DELAY=5 # milliseconds between steps
 
 # Parse arguments
-if [ "$1" = "-d" ]; then
-  DEBUG=true
-  shift
-fi
+while :; do
+  case "$1" in
+    -d) DEBUG=true; shift ;;
+    -p | --preload) PRELOAD=true; shift ;;
+    *) break ;;
+  esac
+done
 
 TERMINAL_CMD="$1"
 
-# Windows we adopt or reuse must look like the terminal we launch. At login
+# Windows we adopt at spawn must look like the terminal we launch. At login
 # this script races other autostarts (xwaylandvideobridge), and a bare
 # new-address diff used to grab whichever window mapped first — yanking the
 # bridge onto the active workspace front and center. Class is matched
@@ -220,16 +226,28 @@ get_terminal_address() {
 # Function to get stored monitor name
 get_terminal_monitor() {
   if [ -f "$ADDR_FILE" ] && [ -s "$ADDR_FILE" ]; then
-    cut -d' ' -f2- "$ADDR_FILE"
+    cut -d' ' -f2 "$ADDR_FILE"
   fi
 }
 
-# Function to check if terminal exists
+# Function to get stored terminal class (recorded at adopt time)
+get_terminal_class() {
+  if [ -f "$ADDR_FILE" ] && [ -s "$ADDR_FILE" ]; then
+    cut -d' ' -f3 "$ADDR_FILE"
+  fi
+}
+
+# The stored window counts as our dropdown only if it is the same window we
+# adopted: address AND class must both match what was recorded. Identity is
+# checked against the file, not against $TERM_BIN, so the keybind toggles
+# the existing dropdown even when invoked with a different terminal than the
+# one that preloaded it — and a poisoned or reused address never qualifies.
 terminal_exists() {
   local addr=$(get_terminal_address)
-  if [ -n "$addr" ]; then
-    hyprctl clients -j | jq -e --arg ADDR "$addr" --arg BIN "$TERM_BIN" \
-      'any(.[]; .address == $ADDR and ((.class // "") | ascii_downcase | contains($BIN | ascii_downcase)))' >/dev/null 2>&1
+  local class=$(get_terminal_class)
+  if [ -n "$addr" ] && [ -n "$class" ]; then
+    hyprctl clients -j | jq -e --arg ADDR "$addr" --arg CLS "$class" \
+      'any(.[]; .address == $ADDR and .class == $CLS)' >/dev/null 2>&1
   else
     return 1
   fi
@@ -292,9 +310,16 @@ spawn_terminal() {
   done
 
   if [ -n "$new_addr" ] && [ "$new_addr" != "null" ]; then
-    # Store the address and monitor name
-    echo "$new_addr $monitor_name" >"$ADDR_FILE"
-    debug_echo "Terminal created with address: $new_addr in special workspace on monitor $monitor_name"
+    # Store address, monitor, and class — class is the identity token
+    # terminal_exists() checks on later invocations.
+    local new_class=$(hyprctl clients -j | jq -r --arg ADDR "$new_addr" '.[] | select(.address == $ADDR) | .class')
+    echo "$new_addr $monitor_name $new_class" >"$ADDR_FILE"
+    debug_echo "Terminal created with address: $new_addr ($new_class) in special workspace on monitor $monitor_name"
+
+    if [ "$PRELOAD" = true ]; then
+      debug_echo "Preload mode: leaving terminal parked in $SPECIAL_WS"
+      return 0
+    fi
 
     # Small delay to ensure it's properly in special workspace
     sleep 0.2
@@ -313,6 +338,17 @@ spawn_terminal() {
 }
 
 # Main logic
+if [ "$PRELOAD" = true ]; then
+  # exec-once path: make sure a dropdown exists in the scratchpad, but never
+  # reveal or focus anything at login.
+  if terminal_exists; then
+    debug_echo "Preload: dropdown already exists"
+  else
+    spawn_terminal
+  fi
+  exit 0
+fi
+
 if terminal_exists; then
   TERMINAL_ADDR=$(get_terminal_address)
   debug_echo "Found existing terminal: $TERMINAL_ADDR"
@@ -330,8 +366,8 @@ if terminal_exists; then
     # Move and resize window
     hyprctl dispatch movewindowpixel "exact $target_x $target_y,address:$TERMINAL_ADDR"
     hyprctl dispatch resizewindowpixel "exact $width $height,address:$TERMINAL_ADDR"
-    # Update ADDR_FILE
-    echo "$TERMINAL_ADDR $monitor_name" >"$ADDR_FILE"
+    # Update ADDR_FILE (keep the recorded class)
+    echo "$TERMINAL_ADDR $monitor_name $(get_terminal_class)" >"$ADDR_FILE"
   fi
 
   if terminal_in_special; then

--- a/config/hypr/scripts/Dropterminal.sh
+++ b/config/hypr/scripts/Dropterminal.sh
@@ -32,6 +32,14 @@ fi
 
 TERMINAL_CMD="$1"
 
+# Windows we adopt or reuse must look like the terminal we launch. At login
+# this script races other autostarts (xwaylandvideobridge), and a bare
+# new-address diff used to grab whichever window mapped first — yanking the
+# bridge onto the active workspace front and center. Class is matched
+# case-insensitively as a substring so app-id styles like
+# org.wezfurlong.wezterm still match "wezterm".
+TERM_BIN=$(basename "${TERMINAL_CMD%% *}")
+
 # Debug echo function
 # NOTE: must write to stderr — several functions return values via stdout
 # command substitution, and debug lines on stdout corrupt those captures.
@@ -220,7 +228,8 @@ get_terminal_monitor() {
 terminal_exists() {
   local addr=$(get_terminal_address)
   if [ -n "$addr" ]; then
-    hyprctl clients -j | jq -e --arg ADDR "$addr" 'any(.[]; .address == $ADDR)' >/dev/null 2>&1
+    hyprctl clients -j | jq -e --arg ADDR "$addr" --arg BIN "$TERM_BIN" \
+      'any(.[]; .address == $ADDR and ((.class // "") | ascii_downcase | contains($BIN | ascii_downcase)))' >/dev/null 2>&1
   else
     return 1
   fi
@@ -262,14 +271,19 @@ spawn_terminal() {
   hyprctl dispatch exec "[float; size $width $height; workspace special:scratchpad silent] $TERMINAL_CMD"
 
   # Wait for the new window to appear (poll up to ~3s; terminals routinely
-  # take >100ms to map, and grabbing the wrong window here means yanking an
-  # unrelated window out of its workspace and pinning it).
+  # take >100ms to map). Only accept a window that landed on the scratchpad
+  # workspace with a matching class — the exec rule above guarantees ours
+  # does, and unrelated windows mapping concurrently (xwaylandvideobridge at
+  # login) must never be adopted, moved, and pinned by mistake.
   local new_addr=""
   local i
   for i in $(seq 1 30); do
     new_addr=$(comm -13 \
       <(echo "$windows_before" | jq -r '.[].address' | sort) \
-      <(hyprctl clients -j | jq -r '.[].address' | sort) |
+      <(hyprctl clients -j | jq -r --arg WS "$SPECIAL_WS" --arg BIN "$TERM_BIN" \
+        '.[] | select(.workspace.name == $WS)
+             | select((.class // "") | ascii_downcase | contains($BIN | ascii_downcase))
+             | .address' | sort) |
       head -1)
     if [ -n "$new_addr" ] && [ "$new_addr" != "null" ]; then
       break


### PR DESCRIPTION
## Description

Fixes xwaylandvideobridge appearing front and center at login.

`Dropterminal.sh` (run from `exec-once` in `Startup_Apps.conf`) identified its freshly spawned terminal by diffing client addresses before/after `hyprctl dispatch exec` and taking the first new one. At login it races other autostarts: on this boot the bridge mapped in that window, so the script adopted the **bridge** instead of the terminal — moving it to the active workspace, pinning it, and running the slide-down animation. It also poisoned `/tmp/dropdown_terminal_addr`, so the dropdown keybind kept toggling the bridge afterwards. (The static `special:xwvb` window rule and the HideXwaylandBridge parker both worked correctly; the Hyprland log showed the yank came from this script's dispatchers.)

Changes:
- The spawn poll only accepts a new window on `special:scratchpad` (where the exec rule places the terminal) whose class matches the launched binary (case-insensitive substring, so app-id styles like `org.wezfurlong.wezterm` match `wezterm`).
- `terminal_exists()` applies the same class check, so a stale or poisoned address file self-heals by respawning instead of hijacking whatever window it points at.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] My commit message follows the commit guidelines.
- [x] I have tested my code locally and it works as expected.

## Additional context

Verified live on styx: show/hide toggle adopts only the kitty scratchpad window and the bridge stays parked on `special:xwvb`; login-path (spawn) verification pending next relog.
